### PR TITLE
Display service name in header

### DIFF
--- a/services/pins-components/pins/components/header/template.njk
+++ b/services/pins-components/pins/components/header/template.njk
@@ -232,12 +232,12 @@
         {% endif %}
       </a>
     </div>
-    <div class="govuk-header__content">
-    {# {% if params.serviceName %}
-    <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">
+     <div class="govuk-header__content">
+    {% if params.serviceName %}
+    <span class="govuk-header__link--service-name">
       {{ params.serviceName }}
-    </a>
-    {% endif %} #}
+    </span>
+    {% endif %}
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide navigation menu') }}">Menu</button>
     {# <nav>
       <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="{{ params.navigationLabel | default('Navigation menu') }}">


### PR DESCRIPTION
Hi @pk2453 @cpcundill , I need help with the styling of the service name line, currently it is  aligned to the right of the screen:
<img width="1158" alt="Screenshot 2022-03-11 at 20 23 24" src="https://user-images.githubusercontent.com/1644854/157956304-472db2db-9933-4e2a-8fea-a0a69e28354a.png">
while it needs to be aligned to the right:
<img width="765" alt="Screenshot 2022-03-11 at 20 24 33" src="https://user-images.githubusercontent.com/1644854/157956584-fcb14988-f19d-4555-80b5-5908fa3216d2.png">

