### PR TITLE
FIX: Reported Accessibility Issues

### DIFF
--- a/services/pins-components/pins/components/footer/template.njk
+++ b/services/pins-components/pins/components/footer/template.njk
@@ -1,4 +1,4 @@
-<div class="govuk-footer pins-footer">
+<footer class="govuk-footer pins-footer">
   <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
@@ -24,4 +24,4 @@
       </div>
     </div>
   </div>
-</div>
+</footer>

--- a/services/pins-components/pins/components/header/template.njk
+++ b/services/pins-components/pins/components/header/template.njk
@@ -238,7 +238,18 @@
       {{ params.serviceName }}
     </span>
     {% endif %} #}
+
+    {#
+      - Commented out <button> from template due to a reported accessibility issue:
+      - Task Title: 'ARIA-Controls Attribute Does Not Point to an ID in the Same Document'
+      - Task URL: https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?modal=detail&selectedIssue=ASB-348
+
+      - Investigation into the history of previous work shows that a navigation section has been commented out from the code.
+      - The button responsible for controlling the navigation remained.
+
       <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide navigation menu') }}">Menu</button>
+    #}
+
       {# <nav>
       <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="{{ params.navigationLabel | default('Navigation menu') }}">
         <li class="govuk-header__navigation-item">


### PR DESCRIPTION
**Important:** Review by all relevant parties would be needed to open discussion concerning the current state of the templates, concerns and potential consequences.

Two .njk template files located in the pins components folders have been updated as a result of an accessibility review that raised a number of issues associated with the applications service site that is currently in development. Two of the raised issues addressed in this PR are associated with the header and the footer components.

1. '[ARIA-Controls Attribute Does Not Point to an ID in the Same Document](https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?modal=detail&selectedIssue=ASB-348)'. Issue has been located in the header. Investigation into the history of previous work (commit URL: https://github.com/Planning-Inspectorate/service-common/commit/31d17bba740c94f5223b083da968f2895977ebe7) shows that a navigation section has been commented out from the code. The button responsible for controlling the navigation remained. To resolve the reported issue I have simply commented out the button to reduce the risk of potential consequences.

2. '[Page Regions Not Identified with ARIA Landmarks](https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?modal=detail&selectedIssue=ASB-345)'. "It's been identified that the ‘Footer’ page region is not identified with an ARIA landmark. It is important that all page regions are identified with ARIA landmarks, as without a landmark page regions may be missed or ignored unintentionally by users of assistive technologies." The documentation provided by the report (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/contentinfo_role) gives an example stating 'This is a website footer. Using the `<footer>` element instead is recommended'.