### PR TITLE
ASB-347: Semantic Markup Not Used Appropriately

### DIFF
--- a/services/pins-components/pins/components/header/template.njk
+++ b/services/pins-components/pins/components/header/template.njk
@@ -281,8 +281,8 @@
 
   {% if params.serviceName %}
     <div class="govuk-header__container {{ params.containerClasses | default('govuk-width-container') }}">
-      <span class="govuk-header__link--service-name">
-        {{ params.serviceName }}
+      <span class="govuk-!-display-inline-block govuk-body-l govuk-!-margin-bottom-2" style="color: inherit;">
+        <strong>{{ params.serviceName }}</strong>
       </span>
     </div>
   {% endif %}


### PR DESCRIPTION
### Task
[[A11y] SortSite - 1.3.1 Info and Relationships – Semantic Markup Not Used Appropriately](https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?modal=detail&selectedIssue=ASB-347)

### Description
- Accessibility review identified that 'CSS font-weight property is used instead of semantic markup like strong'. To amend this issue utility classes have replaced the class containing the font-weight value and the strong element has been added to the markup.